### PR TITLE
Enables Autonomous Nymph Movement

### DIFF
--- a/code/modules/mob/living/carbon/alien/diona/diona.dm
+++ b/code/modules/mob/living/carbon/alien/diona/diona.dm
@@ -40,3 +40,10 @@
 	new_hat.loc = src
 	update_icons()
 
+/mob/living/carbon/alien/diona/proc/handle_npc(var/mob/living/carbon/alien/diona/D)
+	if(D.stat != CONSCIOUS)
+		return
+	if(prob(33) && D.canmove && isturf(D.loc) && !D.pulledby) //won't move if being pulled
+		step(D, pick(cardinal))
+	if(prob(1))
+		D.emote(pick("scratch","jump","chirp","tail"))

--- a/code/modules/mob/living/carbon/alien/diona/life.dm
+++ b/code/modules/mob/living/carbon/alien/diona/life.dm
@@ -20,3 +20,6 @@
 		adjustFireLoss(-1)
 		adjustToxLoss(-1)
 		adjustOxyLoss(-1)
+
+	if(!client)
+		handle_npc(src)


### PR DESCRIPTION
Nymphs without a controller will now move around and emote similar to
how monkeys move and emote. This means they won't be sitting all in a pile after a split.